### PR TITLE
Add manifest validation to common workflow repository

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -1,6 +1,7 @@
 name: Run pre-commit checks
 
 on:
+  push:
   pull_request:
   workflow_call:
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,25 @@
+name: Run tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install test requirements
+        run: |
+          pip install -r test-requirements.txt
+
+      - name: Run tests
+        run: |
+          pytest -v

--- a/.github/workflows/validate-manifests.yaml
+++ b/.github/workflows/validate-manifests.yaml
@@ -1,0 +1,64 @@
+name: Kustomize build overlays
+
+on:
+  workflow_call:
+    inputs:
+      common_ci_repository:
+        type: string
+        description: "Common CI repository name"
+        default: "ocp-on-nerc/workflows"
+        required: false
+      common_ci_ref:
+        type: string
+        description: "Common CI repository reference"
+        default: main
+        required: false
+      schema_repository:
+        type: string
+        description: "API schema repository name"
+        default: "ocp-on-nerc/ocp-api-schemas"
+        required: false
+      schema_ref:
+        type: string
+        description: "API schema repository reference"
+        default: main
+        required: false
+
+jobs:
+  validate-manifests:
+    runs-on: ubuntu-latest
+
+    env:
+      TERM: xterm-256color
+      COMMON_CI: "${{ github.workspace }}/common-ci"
+      OCP_SCHEMAS: "${{ github.workspace }}/ocp-api-schemas"
+      BINDIR: "${{ github.workspace }}/bin"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Check out CI scripts
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.common_ci_repository }}
+          ref: ${{ inputs.common_ci_ref }}
+          path: "${{ env.COMMON_CI }}"
+
+      - name: Checkout additional schema definitions
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.schema_repository }}
+          ref: ${{ inputs.schema_ref }}
+          path: "${{ env.OCP_SCHEMAS }}"
+
+      - name: Install required binaries
+        run: |
+          ${COMMON_CI}/scripts/install-kubeconform.sh
+          ${COMMON_CI}/scripts/install-kustomize.sh
+
+      - name: Validate manifests
+        run: |
+          ${COMMON_CI}/scripts/validate-manifests.sh
+        env:
+          ADDITIONAL_SCHEMAS: "${{ env.OCP_SCHEMAS }}/schemas"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.1.11
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -18,7 +18,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.26.3
+    rev: v1.28.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,10 @@ repos:
         files: \.(yaml|yml)$
         types: [file, yaml]
         entry: yamllint --strict
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.9.0
+    hooks:
+      - id: shellcheck
+        args:
+          - --severity=error

--- a/scripts/install-kubeconform.sh
+++ b/scripts/install-kubeconform.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+: "${KUBECONFORM_VERSION:=0.6.1}"
+
+echo "Installing kubeconform to ${BINDIR}/kubeconform..."
+mkdir -p "$BINDIR"
+curl -Lsf "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" |
+        tar -C "$BINDIR" -xzf- kubeconform

--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+: "${KUSTOMIZE_VERSION:=4.5.7}"
+
+echo "Installing kustomize to ${BINDIR}/kustomize..."
+mkdir -p "$BINDIR"
+curl -Lsf "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" |
+    tar -C "$BINDIR" -xzf- kustomize

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -eu
+
+: "${BINDIR:=""}"
+: "${KUSTOMIZE:=${BINDIR:+${BINDIR}/}kustomize}"
+: "${KUBECONFORM:=${BINDIR:+${BINDIR}/}kubeconform}"
+
+find_overlays() {
+    find . -regex '.*/overlays/[^/]*/kustomization.yaml' -exec dirname {} \;
+}
+
+okay() {
+    echo -n "$(tput setaf 2)${1}:okay$(tput sgr0) "
+}
+
+fail() {
+    echo "$(tput setaf 1)${1}:failed$(tput sgr0)"
+    if [[ -s "$tmpdir/stdout" ]]; then
+        echo
+        cat "$tmpdir/stdout"
+
+        # Annotation for GitHub
+        echo "::error::$(tr '\n' ' ' < "$tmpdir/stdout")"
+    fi
+
+    if [[ -s "$tmpdir/stderr" ]]; then
+        echo
+        cat "$tmpdir/stderr"
+
+        # Annotation for GitHub
+        echo "::error::$(tr '\n' ' ' < "$tmpdir/stderr")"
+    fi
+    exit 1
+}
+
+tmpdir=$(mktemp -d buildXXXXXX)
+trap "rm -rf $tmpdir" EXIT
+
+for overlay in $(find_overlays); do
+    : > "$tmpdir/stdout"
+
+    echo -n "$overlay "
+    if $KUSTOMIZE build "$overlay" > "$tmpdir/manifests.yaml" 2> "$tmpdir/stderr"; then
+        okay build
+    else
+        fail build
+    fi
+
+    if $KUBECONFORM \
+            -schema-location default \
+            ${ADDITIONAL_SCHEMAS:+-schema-location "$ADDITIONAL_SCHEMAS"} \
+            -ignore-missing-schemas \
+            "$tmpdir/manifests.yaml" > "$tmpdir/stdout" 2> "$tmpdir/stderr"; then
+        okay verify
+    else
+        fail verify
+    fi
+
+    echo
+done

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import pytest
+
+@pytest.fixture
+def kubeconform_version():
+    return b"0.6.1"
+
+@pytest.fixture
+def kustomize_version():
+    return b"4.5.7"
+
+@pytest.fixture(autouse=True)
+def set_bindir(tmp_path):
+    if 'BINDIR' not in os.environ:
+        os.environ['BINDIR'] = os.path.join(tmp_path, 'bin')

--- a/tests/test_install_kubeconform.py
+++ b/tests/test_install_kubeconform.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+
+
+def test_install_kubeconform(tmp_path, kubeconform_version):
+    topdir = os.getcwd()
+    subprocess.run(
+        [f"{topdir}/scripts/install-kubeconform.sh"],
+        cwd=tmp_path,
+        env=os.environ | {"KUBECONFORM_VERSION": kubeconform_version},
+        check=True,
+    )
+    out = subprocess.run(
+        [f"{os.environ['BINDIR']}/kubeconform", "-v"], cwd=tmp_path, check=True, capture_output=True
+    )
+    assert kubeconform_version in out.stdout

--- a/tests/test_install_kustomize.py
+++ b/tests/test_install_kustomize.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+
+
+def test_install_kustomize(tmp_path, kustomize_version):
+    topdir = os.getcwd()
+    subprocess.run(
+        [f"{topdir}/scripts/install-kustomize.sh"],
+        cwd=tmp_path,
+        env=os.environ | {"KUSTOMIZE_VERSION": kustomize_version},
+        check=True,
+    )
+    out = subprocess.run(
+        [f"{os.environ['BINDIR']}/kustomize", "version"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    assert kustomize_version in out.stdout

--- a/tests/test_validate_manifests.py
+++ b/tests/test_validate_manifests.py
@@ -1,0 +1,114 @@
+import os
+import subprocess
+import pytest
+import yaml
+
+manifests_should_succeed = {
+    "files": {
+        "overlays/test/kustomization.yaml": {
+            "resources": [
+                "service.yaml",
+            ]
+        },
+        "overlays/test/service.yaml": {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "test-service",
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 80,
+                        "protocol": "TCP",
+                        "name": "http",
+                        "targetPort": "http",
+                    }
+                ],
+            },
+        },
+    },
+}
+
+manifests_should_fail = {
+    "expect_in_output": [
+        "expected array or null, but got object",
+    ],
+    "files": {
+        "overlays/test/kustomization.yaml": {
+            "resources": [
+                "service.yaml",
+            ]
+        },
+        "overlays/test/service.yaml": {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "test-service",
+            },
+            "spec": {
+                "ports": {
+                    "port": "80",
+                    "protocol": "TCP",
+                    "name": "http",
+                    "targetPort": "http",
+                },
+            },
+        },
+    },
+}
+
+
+def write_test_manifests(prefix, manifests):
+    for path, data in manifests["files"].items():
+        fullpath = os.path.join(prefix, path)
+        os.makedirs(os.path.dirname(fullpath), exist_ok=True)
+        with open(fullpath, "w") as fd:
+            yaml.safe_dump(data, fd)
+
+
+@pytest.fixture(autouse=True)
+def setup_environment(tmp_path):
+    topdir = os.getcwd()
+
+    subprocess.check_call(
+        [f"{topdir}/scripts/install-kustomize.sh"],
+        cwd=tmp_path,
+    )
+    subprocess.check_call(
+        [f"{topdir}/scripts/install-kubeconform.sh"],
+        cwd=tmp_path,
+    )
+
+
+def test_validate_manifests_no_manifests(tmp_path):
+    topdir = os.getcwd()
+    subprocess.check_call(
+        [f"{topdir}/scripts/validate-manifests.sh"],
+        cwd=tmp_path,
+    )
+
+
+def test_validate_manifests_okay(tmp_path):
+    topdir = os.getcwd()
+    write_test_manifests(tmp_path, manifests_should_succeed)
+    subprocess.run(
+        [f"{topdir}/scripts/validate-manifests.sh"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+
+def test_validate_manifests_fail(tmp_path):
+    topdir = os.getcwd()
+    write_test_manifests(tmp_path, manifests_should_fail)
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        subprocess.run(
+            [f"{topdir}/scripts/validate-manifests.sh"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        for expected in manifests_should_fail["expected_in_output"]:
+            assert expected in excinfo.value.output


### PR DESCRIPTION
We run a manifest validation script as part of the ocp-on-nerc/nerc-ocp-config repository. We would like to both enhance the validations performed by that script and expose those features to other repositories.

This PR adds the script to our common workflow repository and adds support for [kubeconform][1] for manifest validation.

[1]: https://github.com/yannh/kubeconform


Part of https://github.com/OCP-on-NERC/operations/issues/99