### PR TITLE
Update validation workflow

### DIFF
--- a/.github/workflows/validate-manifests.yaml
+++ b/.github/workflows/validate-manifests.yaml
@@ -65,4 +65,4 @@ jobs:
         run: |
           ${COMMON_CI}/scripts/validate-manifests.sh
         env:
-          ADDITIONAL_SCHEMAS: "${{ env.OCP_SCHEMAS }}/schemas"
+          ADDITIONAL_SCHEMAS: "${{ env.OCP_SCHEMAS }}/schemas.json"

--- a/scripts/install-kubeconform.sh
+++ b/scripts/install-kubeconform.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-: "${KUBECONFORM_VERSION:=0.6.1}"
+: "${KUBECONFORM_VERSION:=0.6.7}"
 
 echo "Installing kubeconform to ${BINDIR}/kubeconform..."
 mkdir -p "$BINDIR"


### PR DESCRIPTION
In order to resolve validation failures on ocp-on-nerc/nerc-ocp-config#609,
we need to update the schema repository. This required some changes to the
repository layout because the tool on which we had been relying was no
longer maintained.

This pull request updates our validation workflow to use the new schema
repository structure.

